### PR TITLE
Fix Kustomize commonLabels deprecation warnings

### DIFF
--- a/k8s/base/solidity-security-docs/kustomization.yaml
+++ b/k8s/base/solidity-security-docs/kustomization.yaml
@@ -11,9 +11,10 @@ resources:
 - serviceaccount.yaml
 - ingress.yaml
 
-commonLabels:
-  app.kubernetes.io/name: solidity-security-docs
-  app.kubernetes.io/component: documentation
-  app.kubernetes.io/part-of: solidity-security-platform
-  app.kubernetes.io/managed-by: kustomize
-  team: platform
+labels:
+- pairs:
+    app.kubernetes.io/name: solidity-security-docs
+    app.kubernetes.io/component: documentation
+    app.kubernetes.io/part-of: solidity-security-platform
+    app.kubernetes.io/managed-by: kustomize
+    team: platform


### PR DESCRIPTION
## Summary
Replaces deprecated `commonLabels:` field with the new `labels:` format.

## Changes
- Updated kustomization.yaml files
- Changed from deprecated `commonLabels:` to `labels:` with `pairs:` syntax

## Before
```yaml
commonLabels:
  key: value
```

## After
```yaml
labels:
- pairs:
    key: value
```

## Testing
- Validated kustomization syntax
- No Kustomize deprecation warnings